### PR TITLE
Implement psr2 multiline function declaration

### DIFF
--- a/Symfony2/ruleset.xml
+++ b/Symfony2/ruleset.xml
@@ -39,6 +39,9 @@
     <rule ref="Squiz.PHP.LowercasePHPFunctions"/>
     <rule ref="Squiz.Scope.MemberVarScope"/>
 
+    <!-- Argument lists MAY be split across multiple lines, where each subsequent line is indented once. When doing so, the first item in the list MUST be on the next line, and there MUST be only one argument per line. When the argument list is split across multiple lines, the closing parenthesis and opening brace MUST be placed together on their own line with one space between them. -->
+    <rule ref="Squiz.Functions.MultiLineFunctionDeclaration"/>
+
     <!-- We provide our own subclass of PEAR's ClassComment and FunctionComment sniff, but these will do: -->
     <rule ref="PEAR.Commenting.InlineComment"/>
 


### PR DESCRIPTION
Argument lists MAY be split across multiple lines, where each
subsequent line is indented once. When doing so, the first item in the
list MUST be on the next line, and there MUST be only one argument per
line. When the argument list is split across multiple lines, the closing
parenthesis and opening brace MUST be placed together on their own line
with one space between them.

Close #3