### PR TITLE
Fix PHP_CodeSniffer version to 1.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+composer.lock
+vendor/

--- a/composer.json
+++ b/composer.json
@@ -13,6 +13,9 @@
         "source": "https://github.com/M6Web/Symfony2-coding-standard",
         "issues": "https://github.com/M6Web/Symfony2-coding-standard/issues"
     },
+    "require": {
+        "squizlabs/php_codesniffer": "~1.0"
+    },
     "suggest": {
         "squizlabs/php_codesniffer": "PHP CodeSniffer",
         "m6web/coke": "PHP CodeSniffer configurator"


### PR DESCRIPTION
The only purpose of this PR is to clearly mark the maximum PHP_CodeSniffer version for actual Symfony2 standard version